### PR TITLE
Improve error handling

### DIFF
--- a/csl_demo/BigInt.gd
+++ b/csl_demo/BigInt.gd
@@ -1,0 +1,55 @@
+extends RefCounted
+
+class_name BigInt
+
+## You should not create a [BigInt] with [BigInt.new].
+## Instead you should use the [BigInt.from_str] or [BigInt.from_int] conversion
+## methods. Alternatively, you can use [BigInt.one] or [BigInt.zero] to get those
+## numbers.
+
+enum Status { SUCCESS = 0, COULD_NOT_PARSE_BIGINT = 1, COULD_NOT_CONVERT_FROM_INT = 2 }
+
+var _b: _BigInt
+
+func _init(b: _BigInt) -> void:
+	_b = b
+
+class ConversionResult extends Result:
+	## WARNING: This function may fail! First match on [Result_.tag] or call [Result_.is_ok].
+	var value: BigInt:
+		get: return BigInt.new(_res.unsafe_value() as _BigInt)
+	## WARNING: This function may fail! First match on [Result_.tag] or call [Result._is_err].
+	var error: String:
+		get: return _res.unsafe_error()
+
+## Create a [BigInt] by parsing a [String].
+static func from_str(s: String) -> ConversionResult:
+	return ConversionResult.new(_BigInt._from_str(s))
+	
+## Convert an [int] into a [BigInt].
+static func from_int(n: int) -> ConversionResult:
+	return ConversionResult.new(_BigInt._from_int(n))
+
+static func zero() -> BigInt:
+	return BigInt.new(_BigInt.zero())
+	
+static func one() -> BigInt:
+	return BigInt.new(_BigInt.zero())
+	
+func add(other: BigInt) -> BigInt:
+	return BigInt.new(_b.add(other._b))
+	
+func mul(other: BigInt) -> BigInt:
+	return BigInt.new(_b.mul(other._b))
+	
+func eq(other: BigInt) -> bool:
+	return _b.eq(other._b)
+	
+func lt(other: BigInt) -> bool:
+	return _b.lt(other._b)
+	
+func gt(other: BigInt) -> bool:
+	return _b.gt(other._b)
+	
+func to_str() -> String:
+	return _b.to_str()

--- a/csl_demo/Cardano.gd
+++ b/csl_demo/Cardano.gd
@@ -1,36 +1,65 @@
-extends _Cardano
+extends Node
 
 class_name Cardano
 
+## This signal is emitted shortly after getting the protocol parameters from the
+## blockchain, after object initialization.
+signal got_tx_builder(initialized: bool)
+
+## This signal is emitted after a wallet is set
+signal got_wallet
+
 var provider: Provider
 var wallet: Wallet
+var tx_builder: TxBuilder
 
-func _init(provider: Provider):
-	self.provider = provider
+func _init(provider_: Provider) -> void:
+	self.provider = provider_
 	self.wallet = null
+	self.tx_builder = null
 	add_child(provider)
-	provider.got_protocol_parameters.connect(_on_got_protocol_parameters)
+	if provider.got_protocol_parameters.connect(_on_got_protocol_parameters) == ERR_INVALID_PARAMETER:
+		push_error("Failed to connect provider's 'got_protocol_parameters' signal ")
 
-func _ready():
-	provider.get_protocol_parameters()
+func _ready() -> void:
+	@warning_ignore("redundant_await")
+	var _params := await provider.get_protocol_parameters()
 
-func _on_got_protocol_parameters(params: ProtocolParameters):
-	set_protocol_parameters(params)
+func _on_got_protocol_parameters(params: ProtocolParameters) -> void:
+	var result := TxBuilder.create(params)
+	match result.tag():
+		TxBuilder.Status.SUCCESS:
+			tx_builder = result.value
+			got_tx_builder.emit()
+		TxBuilder.Status.BAD_PROTOCOL_PARAMETERS:
+			push_error("Failed to initialize tx_builder: bad protocol parameters", result.error)
 
-func send_lovelace_to(recipient: String, amount: BigInt):
-	var change_address = await wallet.get_change_address()
-	var utxos = await wallet.get_utxos()
-	var total_lovelace = await wallet.total_lovelace()
+func send_lovelace_to(recipient: String, amount: BigInt) -> void:
+	@warning_ignore("redundant_await")
+	var change_address := await wallet.get_change_address()
+	@warning_ignore("redundant_await")
+	var utxos := await wallet.get_utxos()
+	var total_lovelace := await wallet.total_lovelace()
 	
 	if amount.gt(total_lovelace):
 		print("Error: not enough lovelace in wallet")
 		return
 		
-	var transaction: Transaction = send_lovelace(recipient, change_address, amount, utxos)
+	var transaction: Transaction = tx_builder.send_lovelace(recipient, change_address, amount, utxos)
 	transaction.add_signature(wallet.sign_transaction(transaction))
 	print(transaction.bytes().hex_encode())
 	provider.submit_transaction(transaction.bytes())
 
-func set_wallet_from_mnemonic(phrase: String):
-	self.wallet = Wallet.MnemonicWallet.new(phrase, self.provider)
-	add_child(self.wallet)
+# FIXME: Return a Result
+func set_wallet_from_mnemonic(phrase_str: String) -> Wallet.MnemonicWallet:
+	var result := PrivateKeyAccount.from_mnemonic(phrase_str)
+	match result.tag():
+		PrivateKeyAccount.Status.SUCCESS:
+			var account := result.value
+			self.wallet = Wallet.MnemonicWallet.new(account, self.provider)
+			add_child(self.wallet)
+			got_wallet.emit()
+			return self.wallet
+		_:
+			push_error("Error found while creating wallet from mnemonic", result.error)
+			return null

--- a/csl_demo/PrivateKeyAccount.gd
+++ b/csl_demo/PrivateKeyAccount.gd
@@ -1,0 +1,42 @@
+extends RefCounted
+
+## You should not create a [PrivateKeyAccount] with [PrivateKeyAccount.new],
+## instead you should use [PrivateKeyAccount.create].
+
+class_name PrivateKeyAccount
+
+enum Status { SUCCESS = 0, BAD_PHRASE = 1, BECH32_ERROR = 2 }
+
+var _account : _PrivateKeyAccount
+
+func _init(account: _PrivateKeyAccount) -> void:
+	self._account = account
+
+class FromMnemonicResult extends Result:
+	## WARNING: This function may fail! First match on [Result_.tag] or call [Result_.is_ok].
+	var value: PrivateKeyAccount:
+		get: return PrivateKeyAccount.new(_res.unsafe_value() as _PrivateKeyAccount)
+	## WARNING: This function may fail! First match on [Result_.tag] or call [Result._is_err].
+	var error: String:
+		get: return _res.unsafe_error()
+
+## Construct a [PrivateKeyAccount] from a mnemonic [param phrase]. The phrase should follow the
+## BIP32 standard.
+static func from_mnemonic(phrase: String) -> FromMnemonicResult:
+	return FromMnemonicResult.new(_PrivateKeyAccount._from_mnemonic(phrase))
+	
+class GetAddressResult extends Result:
+	## WARNING: This function may fail! First match on [Result_.tag] or call [Result_.is_ok].
+	var value: String:
+		get: return _res.unsafe_value()
+	## WARNING: This function may fail! First match on [Result_.tag] or call [Result._is_err].
+	var error: String:
+		get: return _res.unsafe_error()
+	
+## Get the account's address as a BECH32-encoded [String].
+func get_address_bech32() -> GetAddressResult:
+	return GetAddressResult.new(_account._get_address_bech32())
+	
+## Sign the given [Transaction] and obtain a [Signature]
+func sign_transaction(tx: Transaction) -> Signature:
+	return _account._sign_transaction(tx._tx)

--- a/csl_demo/Provider.gd
+++ b/csl_demo/Provider.gd
@@ -4,16 +4,16 @@ class_name Provider
 
 enum Network {NETWORK_MAINNET, NETWORK_PREVIEW, NETWORK_PREPROD}
 
-func _init():
+func _init() -> void:
 	pass
 	
 func get_protocol_parameters() -> ProtocolParameters:
 	return null
 
-func get_utxos_at_address(address: String) -> Array[Utxo]:
+func get_utxos_at_address(_address: String) -> Array[Utxo]:
 	return []
 
-func submit_transaction(tx_cbor: PackedByteArray) -> void:
+func submit_transaction(_tx_cbor: PackedByteArray) -> void:
 	pass
 
 signal got_protocol_parameters(parameters: ProtocolParameters)

--- a/csl_demo/Result.gd
+++ b/csl_demo/Result.gd
@@ -1,0 +1,24 @@
+extends RefCounted
+
+## A class that represents an arbitrary result from executing an operation. This
+## class should never be used directly, it's only meant to be inherited from.
+
+class_name Result
+
+var _res : _Result
+
+func _init(res: _Result) -> void:
+	_res = res
+
+## Returns true if the operation succeeded
+func is_ok() -> bool:
+	return _res.is_ok()
+
+## Returns true if the operation failed
+func is_err() -> bool:
+	return _res.is_err()
+
+## Returns a tag representing the status of the operation. This can
+## be used in pattern matching.	Consult the [Status] enum of the class.
+func tag() -> int:
+	return _res.tag()

--- a/csl_demo/Transaction.gd
+++ b/csl_demo/Transaction.gd
@@ -1,0 +1,14 @@
+extends RefCounted
+
+class_name Transaction
+
+var _tx: _Transaction
+
+func _init(tx: _Transaction) -> void:
+	_tx = tx
+	
+func bytes() -> PackedByteArray:
+	return _tx.bytes()
+
+func add_signature(signature: Signature) -> void:
+	_tx.add_signature(signature)

--- a/csl_demo/TxBuilder.gd
+++ b/csl_demo/TxBuilder.gd
@@ -1,0 +1,40 @@
+extends RefCounted
+
+class_name TxBuilder
+
+## You should not create a [TxBuilder] with [TxBuilder.new], instead
+## you should use [TxBuilder.create].
+
+enum Status { SUCCESS = 0, BAD_PROTOCOL_PARAMETERS = 1 }
+
+var _builder: _TxBuilder
+
+func _init(builder: _TxBuilder) -> void:
+	self._builder = builder
+	
+class CreateResult extends Result:
+	## WARNING: This function may fail! First match on `tag` or call `is_ok`.
+	var value: TxBuilder:
+		get: return TxBuilder.new(_res.unsafe_value() as _TxBuilder)
+	## WARNING: This function may fail! First match on `tag` or call `is_err`.
+	var error: String:
+		get: return _res.unsafe_error()
+
+## Create a TxBuilder object from a ProtocolParameters. This action may fail.
+static func create(params: ProtocolParameters) -> CreateResult:
+	var res : CreateResult = CreateResult.new(_TxBuilder._create(params))
+	return res
+	
+func send_lovelace(recipient_bech32: String, change_address_bech32: String, amount: BigInt, gutxos: Array[Utxo]) -> Transaction:
+	var gutxos_: Array[_Utxo] = []
+	gutxos_.assign(gutxos.map(func(utxo: Utxo) -> _Utxo: return utxo._utxo) as Array[_Utxo])
+		
+	var _tx : _Transaction = _builder.send_lovelace(
+		recipient_bech32,
+		change_address_bech32,
+		amount._b,
+		gutxos_)
+
+	return Transaction.new(_tx)
+
+	

--- a/csl_demo/TxBuilderResult.gd
+++ b/csl_demo/TxBuilderResult.gd
@@ -1,0 +1,3 @@
+extends Result
+
+class_name TxBuilderResult

--- a/csl_demo/Utxo.gd
+++ b/csl_demo/Utxo.gd
@@ -1,0 +1,25 @@
+extends RefCounted
+
+class_name Utxo
+
+var _utxo : _Utxo
+
+func tx_hash() -> String:
+	return _utxo.tx_hash
+
+func output_index() -> int:
+	return _utxo.output_index
+
+func address() -> String:
+	return _utxo.address
+
+func coin() -> BigInt:
+	return BigInt.new(_utxo.coin)
+
+func assets() -> Dictionary:
+	return _utxo.assets
+
+func _init(tx_hash_: String, output_index_: int, address_: String, coin_: BigInt, assets_: Dictionary) -> void:
+	_utxo = _Utxo.create(tx_hash_, output_index_, address_, coin_._b, assets_)
+	
+

--- a/csl_demo/Wallet.gd
+++ b/csl_demo/Wallet.gd
@@ -2,6 +2,8 @@ extends Node
 
 class_name Wallet
 
+signal got_updated_utxos(utxos: Array[Utxo])
+
 var active: bool = false
 
 func get_utxos() -> Array[Utxo]:
@@ -11,38 +13,91 @@ func get_change_address() -> String:
 	return ""
 	
 func total_lovelace() -> BigInt:
-	var utxos = await self.get_utxos()
+	var utxos := await self.get_utxos()
 	return utxos.reduce(
-		func (accum: BigInt, utxo: Utxo): return accum.add(utxo.coin),
+		func (accum: BigInt, utxo: Utxo) -> BigInt: return accum.add(utxo.coin()),
 		BigInt.zero()
 	)
 
-func sign_transaction(transaction: Transaction) -> Signature:
+func sign_transaction(_transaction: Transaction) -> Signature:
 	return null
 	
 class MnemonicWallet extends Wallet:
 	var provider: Provider
 	var private_key_account: PrivateKeyAccount
+
+	@export
+	var utxos_update_age: float = 30
+	@export
+	var utxos_cache_age: float = 30
+
+	# Time left before the Utxos are refreshed. If equal to zero, then the utxos
+	# are currently being fetched.
+	var time_left: float:
+		get: return timer.time_left
+	
+	var timer: Timer
+	
+	## Cached utxos, these can and _will_ be outdated. To get the latest utxos,
+	## call [MnemonicWallet.get_utxos].
 	var utxos: Array[Utxo] = []
-	var update: float = 0
-	var update_interval: float = 2
 		
-	func _init(phrase: String, provider: Provider):
-		self.provider = provider
-		self.private_key_account = PrivateKeyAccount.from_mnemonic(phrase)
+	func _init(account: PrivateKeyAccount, provider_: Provider) -> void:
+		self.provider = provider_
+		self.private_key_account = account
 		self.active = true
+		# Connect and start the timer
+		timer = Timer.new()
+		timer.one_shot = false
+		timer.autostart = true
+		var _status := timer.timeout.connect(update_utxos)
+		timer.wait_time = utxos_update_age
+		add_child(timer)
+		# Initialize UTxOs immediately
+		update_utxos()
 		
-	func _process(delta: float):
-		update -= delta
+	## Update the cached utxos. The same as [MnemonicWallet.get_utxos], but
+	## without returning the updated utxos.
+	func update_utxos() -> void:
+		print_debug("update_utxos called")
+		var _utxos := await self.get_updated_utxos()
+		return
 		
+	## Return the cached UTxOs in the wallet. These may be outdated.
 	func get_utxos() -> Array[Utxo]:
-		if update <= 0:
-			update = update_interval
-			utxos = await self.provider.get_utxos_at_address(private_key_account.get_address_bech32())
-		return utxos
+		#print_debug("get_utxos called")
+		if self.timer.time_left > utxos_cache_age:
+			var new_utxos := await get_updated_utxos()
+			return new_utxos
+		else:
+			return self.utxos
+	
+	## Asynchronously obtain the wallet's UTxOs. This method will fetch them
+	## from the blockchain and the response will represent the wallet's state
+	## at the time the request was made.
+	##
+	## It will also update the cached utxos and reset the timer.
+	func get_updated_utxos() -> Array[Utxo]:
+		print_debug("get_updated_utxos called")
+		self.timer.stop()
+		var result := private_key_account.get_address_bech32()
+		if result.is_ok():
+			var address := result.value
+			self.utxos = await self.provider.get_utxos_at_address(address)
+		else:
+			push_error("An error was found while getting the address of an account", result.error)
+		got_updated_utxos.emit(self.utxos)
+		self.timer.start()
+		return self.utxos
 		
 	func get_change_address() -> String:
-		return self.private_key_account.get_address_bech32()
+		var result := private_key_account.get_address_bech32()
+		match result.tag():
+			PrivateKeyAccount.Status.SUCCESS:
+				return result.value
+			_:
+				push_error("An error was found while getting the address of an account", result.error)
+				return ""
 		
 	func sign_transaction(transaction: Transaction) -> Signature:
 		return private_key_account.sign_transaction(transaction)

--- a/csl_demo/main.gd
+++ b/csl_demo/main.gd
@@ -1,39 +1,64 @@
 extends Node2D
 
 var cardano: Cardano
+var wallet: Wallet.MnemonicWallet
 
-func _ready():
+@onready
+var wallet_details: RichTextLabel = %WalletDetails
+@onready
+var address_input: LineEdit = %AddressInput
+@onready
+var amount_input: LineEdit = %AmountInput
+@onready
+var phrase_input: TextEdit = %PhraseInput
+@onready
+var timers_details: Label = %WalletTimers
+@onready
+var send_ada_button: Button = %SendAdaButton
+
+func _ready() -> void:
 	var token : String = FileAccess\
 		.open("./preview_token.txt", FileAccess.READ)\
 		.get_as_text(true)\
 		.replace("\n", "")
-	print(token.c_escape())
 	var provider: Provider = await BlockfrostProvider.new(
 		Provider.Network.NETWORK_PREVIEW,
 		token
 	)
 	cardano = Cardano.new(provider)
 	add_child(cardano)
-
-func _process(delta: float):
-	if cardano.wallet != null and cardano.wallet.active:
-		var utxos = await cardano.wallet.get_utxos()
-		var num_utxos = utxos.size()
-		var total_lovelace = utxos.reduce(
-			func (acc, utxo): return acc.add(utxo.coin),
-			BigInt.zero()
-		)
-		$WalletDetails.text = "Using wallet %s" % cardano.wallet.get_change_address()
-		if num_utxos > 0:
-			$WalletDetails.text += "\n\nFound %s UTxOs with %s lovelace" % [str(num_utxos), total_lovelace.to_str()]		
-	else:
-		$WalletDetails.text = "No wallet set"
-
-func _on_set_wallet_button_pressed():
-	cardano.set_wallet_from_mnemonic($SetWalletForm/MnemonicPhrase/Input.text)
-
-func _on_send_ada_button_pressed():
-	var address = $SendAdaForm/Recipient/Input.text
-	var amount = BigInt.from_str($SendAdaForm/Amount/Input.text)
 	
-	cardano.send_lovelace_to(address, amount)
+	# Connect signals to wallet details functions
+	wallet_details.text = "No wallet set"
+	var _ret := self.cardano.got_wallet.connect(_on_wallet_set)
+	
+
+func _process(_delta: float) -> void:
+	if wallet != null:
+		timers_details.text = "Timer: %.2f" % wallet.time_left
+
+func _on_wallet_set() -> void:
+	var _ret := self.cardano.wallet.got_updated_utxos.connect(_on_utxos_updated)
+	wallet_details.text = "Using wallet %s" % cardano.wallet.get_change_address()
+	send_ada_button.disabled = false
+	
+func _on_utxos_updated(utxos: Array[Utxo]) -> void:
+	var num_utxos := utxos.size()
+	var total_lovelace : BigInt = utxos.reduce(
+		func (acc: BigInt, utxo: Utxo) -> BigInt: return acc.add(utxo.coin()),
+		BigInt.zero()
+	)
+	wallet_details.text = "Using wallet %s" % cardano.wallet.get_change_address()
+	if num_utxos > 0:
+		wallet_details.text += "\n\nFound %s UTxOs with %s lovelace" % [str(num_utxos), total_lovelace.to_str()]		
+
+func _on_set_wallet_button_pressed() -> void:
+	wallet = cardano.set_wallet_from_mnemonic(phrase_input.text)
+
+func _on_send_ada_button_pressed() -> void:
+	var address := address_input.text
+	var res: BigInt.ConversionResult = BigInt.from_str(amount_input.text)
+	if res.is_ok():
+		cardano.send_lovelace_to(address, res.value)
+	else:
+		push_error("There was an error while parsing the amount as a BigInt", res.error)

--- a/csl_demo/main.tscn
+++ b/csl_demo/main.tscn
@@ -5,7 +5,20 @@
 [node name="main" type="Node2D"]
 script = ExtResource("1_6enfc")
 
+[node name="WalletTimers" type="Label" parent="."]
+unique_name_in_owner = true
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = 1024.0
+offset_right = 1025.0
+offset_bottom = 23.0
+grow_horizontal = 0
+size_flags_horizontal = 8
+size_flags_vertical = 0
+
 [node name="WalletDetails" type="RichTextLabel" parent="."]
+unique_name_in_owner = true
 offset_left = 52.0
 offset_top = 367.0
 offset_right = 1128.0
@@ -17,7 +30,8 @@ selection_enabled = true
 
 [node name="MnemonicPhrase" type="Node2D" parent="SetWalletForm"]
 
-[node name="Input" type="TextEdit" parent="SetWalletForm/MnemonicPhrase"]
+[node name="PhraseInput" type="TextEdit" parent="SetWalletForm/MnemonicPhrase"]
+unique_name_in_owner = true
 offset_left = 49.0
 offset_top = 33.0
 offset_right = 819.0
@@ -40,10 +54,12 @@ text = "Set wallet"
 [node name="SendAdaForm" type="Node2D" parent="."]
 
 [node name="SendAdaButton" type="Button" parent="SendAdaForm"]
+unique_name_in_owner = true
 offset_left = 47.0
 offset_top = 579.0
 offset_right = 247.0
 offset_bottom = 621.0
+disabled = true
 text = "Send ADA
 "
 
@@ -56,7 +72,8 @@ offset_right = 166.0
 offset_bottom = 527.0
 text = "Recipient:"
 
-[node name="Input" type="LineEdit" parent="SendAdaForm/Recipient"]
+[node name="AddressInput" type="LineEdit" parent="SendAdaForm/Recipient"]
+unique_name_in_owner = true
 offset_left = 149.0
 offset_top = 496.0
 offset_right = 790.0
@@ -71,7 +88,8 @@ offset_right = 136.0
 offset_bottom = 560.0
 text = "Amount:"
 
-[node name="Input" type="LineEdit" parent="SendAdaForm/Amount"]
+[node name="AmountInput" type="LineEdit" parent="SendAdaForm/Amount"]
+unique_name_in_owner = true
 offset_left = 150.0
 offset_top = 535.0
 offset_right = 380.0

--- a/csl_demo/project.godot
+++ b/csl_demo/project.godot
@@ -14,3 +14,13 @@ config/name="GDExtensionTest"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"
+
+[debug]
+
+gdscript/warnings/untyped_declaration=1
+gdscript/warnings/unsafe_property_access=1
+gdscript/warnings/unsafe_method_access=1
+gdscript/warnings/unsafe_cast=1
+gdscript/warnings/unsafe_call_argument=1
+gdscript/warnings/return_value_discarded=1
+

--- a/csl_demo/project.godot
+++ b/csl_demo/project.godot
@@ -23,4 +23,3 @@ gdscript/warnings/unsafe_method_access=1
 gdscript/warnings/unsafe_cast=1
 gdscript/warnings/unsafe_call_argument=1
 gdscript/warnings/return_value_discarded=1
-

--- a/libcsl_godot/src/bigint.rs
+++ b/libcsl_godot/src/bigint.rs
@@ -21,13 +21,17 @@ pub enum BigIntError {
 }
 
 impl GodotConvert for BigIntError {
-    type Via = GString;
+    type Via = i64;
 }
 
 // TODO: Improve error strings
 impl ToGodot for BigIntError {
     fn to_godot(&self) -> Self::Via {
-        GString::from(format!("{:?}", self))
+        use BigIntError::*;
+        match self {
+            CouldNotParseBigInt(_) => 1,
+            CouldNotConvertFromInt(_) => 2,
+        }
     }
 }
 

--- a/libcsl_godot/src/bigint.rs
+++ b/libcsl_godot/src/bigint.rs
@@ -1,0 +1,110 @@
+use std::ops::Deref;
+
+use crate::gresult::{FailsWith, GResult};
+use cardano_serialization_lib::error::JsError;
+use cardano_serialization_lib::utils as CSL;
+use godot::builtin::meta::GodotConvert;
+use godot::prelude::*;
+
+#[derive(GodotClass, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[class(init, base=RefCounted)]
+pub struct BigInt {
+    #[init(default = CSL::BigInt::from_str("0").unwrap())]
+    #[doc(hidden)]
+    pub b: CSL::BigInt,
+}
+
+#[derive(Debug)]
+pub enum BigIntError {
+    CouldNotParseBigInt(JsError),
+    CouldNotConvertFromInt(JsError),
+}
+
+impl GodotConvert for BigIntError {
+    type Via = GString;
+}
+
+// TODO: Improve error strings
+impl ToGodot for BigIntError {
+    fn to_godot(&self) -> Self::Via {
+        GString::from(format!("{:?}", self))
+    }
+}
+
+impl FailsWith for BigInt {
+    type E = BigIntError;
+}
+
+#[godot_api]
+impl BigInt {
+    pub fn from_str_(text: String) -> Result<BigInt, BigIntError> {
+        CSL::BigInt::from_str(&text).map_or_else(
+            |e| Result::Err(BigIntError::CouldNotParseBigInt(e)),
+            |b| Result::Ok(Self { b }),
+        )
+    }
+
+    #[func]
+    pub fn from_str(text: String) -> Gd<GResult> {
+        Self::to_gresult_class(Self::from_str_(text))
+    }
+
+    #[func]
+    pub fn to_str(&self) -> String {
+        return self.b.to_str();
+    }
+
+    #[func]
+    pub fn to_string(&self) -> String {
+        return self.to_str();
+    }
+
+    pub fn from_int_(n: i64) -> Result<BigInt, BigIntError> {
+        CSL::BigInt::from_str(&n.to_string()).map_or_else(
+            |e| Result::Err(BigIntError::CouldNotConvertFromInt(e)),
+            |b| Result::Ok(Self { b }),
+        )
+    }
+
+    #[func]
+    pub fn from_int(n: i64) -> Gd<GResult> {
+        Self::to_gresult_class(Self::from_int_(n))
+    }
+
+    #[func]
+    fn add(&self, other: Gd<BigInt>) -> Gd<BigInt> {
+        let b = self.b.add(&other.bind().deref().b);
+        return Gd::from_object(Self { b });
+    }
+
+    #[func]
+    fn mul(&self, other: Gd<BigInt>) -> Gd<BigInt> {
+        let b = self.b.mul(&other.bind().deref().b);
+        return Gd::from_object(Self { b });
+    }
+
+    #[func]
+    fn zero() -> Gd<GResult> {
+        return Self::from_str("0".to_string());
+    }
+
+    #[func]
+    fn one() -> Gd<GResult> {
+        return Self::from_str("1".to_string());
+    }
+
+    #[func]
+    fn eq(&self, other: Gd<BigInt>) -> bool {
+        return self.b == other.bind().b;
+    }
+
+    #[func]
+    fn gt(&self, other: Gd<BigInt>) -> bool {
+        return self > &other.bind();
+    }
+
+    #[func]
+    fn lt(&self, other: Gd<BigInt>) -> bool {
+        return self < &other.bind();
+    }
+}

--- a/libcsl_godot/src/bigint.rs
+++ b/libcsl_godot/src/bigint.rs
@@ -7,7 +7,7 @@ use godot::builtin::meta::GodotConvert;
 use godot::prelude::*;
 
 #[derive(GodotClass, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[class(init, base=RefCounted)]
+#[class(init, base=RefCounted, rename=_BigInt)]
 pub struct BigInt {
     #[init(default = CSL::BigInt::from_str("0").unwrap())]
     #[doc(hidden)]
@@ -24,7 +24,6 @@ impl GodotConvert for BigIntError {
     type Via = i64;
 }
 
-// TODO: Improve error strings
 impl ToGodot for BigIntError {
     fn to_godot(&self) -> Self::Via {
         use BigIntError::*;
@@ -41,7 +40,7 @@ impl FailsWith for BigInt {
 
 #[godot_api]
 impl BigInt {
-    pub fn from_str_(text: String) -> Result<BigInt, BigIntError> {
+    pub fn from_str(text: String) -> Result<BigInt, BigIntError> {
         CSL::BigInt::from_str(&text).map_or_else(
             |e| Result::Err(BigIntError::CouldNotParseBigInt(e)),
             |b| Result::Ok(Self { b }),
@@ -49,8 +48,8 @@ impl BigInt {
     }
 
     #[func]
-    pub fn from_str(text: String) -> Gd<GResult> {
-        Self::to_gresult_class(Self::from_str_(text))
+    pub fn _from_str(text: String) -> Gd<GResult> {
+        Self::to_gresult_class(Self::from_str(text))
     }
 
     #[func]
@@ -63,7 +62,7 @@ impl BigInt {
         return self.to_str();
     }
 
-    pub fn from_int_(n: i64) -> Result<BigInt, BigIntError> {
+    pub fn from_int(n: i64) -> Result<BigInt, BigIntError> {
         CSL::BigInt::from_str(&n.to_string()).map_or_else(
             |e| Result::Err(BigIntError::CouldNotConvertFromInt(e)),
             |b| Result::Ok(Self { b }),
@@ -71,8 +70,8 @@ impl BigInt {
     }
 
     #[func]
-    pub fn from_int(n: i64) -> Gd<GResult> {
-        Self::to_gresult_class(Self::from_int_(n))
+    pub fn _from_int(n: i64) -> Gd<GResult> {
+        Self::to_gresult_class(Self::from_int(n))
     }
 
     #[func]
@@ -88,13 +87,17 @@ impl BigInt {
     }
 
     #[func]
-    fn zero() -> Gd<GResult> {
-        return Self::from_str("0".to_string());
+    fn zero() -> Gd<BigInt> {
+        Gd::from_object(Self {
+            b: CSL::BigInt::from_str("0").expect("unexpected error in zero() method"),
+        })
     }
 
     #[func]
-    fn one() -> Gd<GResult> {
-        return Self::from_str("1".to_string());
+    fn one() -> Gd<BigInt> {
+        Gd::from_object(Self {
+            b: CSL::BigInt::from_str("1").expect("unexpected error in one() method"),
+        })
     }
 
     #[func]

--- a/libcsl_godot/src/gdutils.rs
+++ b/libcsl_godot/src/gdutils.rs
@@ -1,0 +1,39 @@
+//! A class for storing useful functions that should not / cannot belong to
+//! other classes.
+//!
+//! For example, some classes have partial constructors that cannot be
+//! implemented as static methods due godot-rust not supporting them.
+
+use cardano_serialization_lib::{
+    fees::LinearFee, tx_builder::TransactionBuilderConfigBuilder, utils::to_bignum,
+};
+use godot::prelude::*;
+
+use crate::{ProtocolParameters, TxBuilder, TxBuilderError};
+
+#[derive(GodotClass)]
+#[class(init, base=Object)]
+struct Utils {}
+
+// #[godot_api]
+// impl Utils {
+//     #[func]
+//     fn create_protocol_parameters(
+//         params: &ProtocolParameters,
+//     ) -> Result<TxBuilder, TxBuilderError> {
+//         let tx_builder_config = TransactionBuilderConfigBuilder::new()
+//             .coins_per_utxo_byte(&to_bignum(params.coins_per_utxo_byte))
+//             .pool_deposit(&to_bignum(params.pool_deposit))
+//             .key_deposit(&to_bignum(params.key_deposit))
+//             .max_value_size(params.max_value_size)
+//             .max_tx_size(params.max_tx_size)
+//             .fee_algo(&LinearFee::new(
+//                 &to_bignum(params.linear_fee_coefficient),
+//                 &to_bignum(params.linear_fee_constant),
+//             ))
+//             .build()
+//             .map_err(|e| TxBuilderError::BadProtocolParameters(e))?;
+
+//         Ok(TxBuilder { tx_builder_config })
+//     }
+// }

--- a/libcsl_godot/src/gresult.rs
+++ b/libcsl_godot/src/gresult.rs
@@ -13,7 +13,7 @@ use std::fmt::Debug;
 /// The class has no `init`, so it cannot be created from GDScript.
 /// This is fine, our users should not need to create `GResult`s.
 #[derive(GodotClass, Debug)]
-#[class(base=RefCounted, rename=Result_)]
+#[class(base=RefCounted, rename=_Result)]
 pub struct GResult {
     #[doc(hidden)]
     result: Result<Variant, GString>,
@@ -43,6 +43,9 @@ impl GResult {
     pub fn unsafe_error(&self) -> GString {
         self.result.clone().unwrap_err()
     }
+
+    // #[func]
+    // pub fn map(&mut self, Callable)
 }
 
 /// Trait used for assuring that all classes consistently use their own

--- a/libcsl_godot/src/gresult.rs
+++ b/libcsl_godot/src/gresult.rs
@@ -1,0 +1,68 @@
+//! The goal of this module is to introduce a class called `GResult`
+//! which is a light wrapper over `Result`. The idea is to allow different
+//! classes implemented in Rust to preserve type information about their methods'
+//! returned types as well as the different errors they might produce; all while still
+//! allowing GDScript access this information too.
+//!
+//! The challenge is that gdext's macros don't support generic types, so we
+//! can't easily do the task at hand without a lot of repetition.
+
+use godot::prelude::*;
+
+/// Class used for communicating results to GDScript.
+/// The class has no `init`, so it cannot be created from GDScript.
+/// This is fine, our users should not need to create `GResult`s.
+#[derive(GodotClass)]
+#[class(base=RefCounted)]
+pub struct GResult {
+    #[doc(hidden)]
+    result: Result<Variant, Variant>,
+}
+
+#[godot_api]
+impl GResult {
+    #[func]
+    pub fn is_ok(&self) -> bool {
+        self.result.is_ok()
+    }
+    #[func]
+    pub fn is_err(&self) -> bool {
+        self.result.is_err()
+    }
+    /// A user should call `get` on a `GResult` and match on the resulting
+    /// dictionary to get the value they want.
+    #[func]
+    pub fn get(&self) -> Dictionary {
+        match &self.result {
+            Ok(val) => Dictionary::from([(&"value", val)]),
+            Err(err) => Dictionary::from([(&"error", err)]),
+        }
+    }
+}
+
+/// Trait used for assuring that all types consistently use their own
+/// pre-defined set of error codes.
+pub trait FailsWith {
+    type E: ToGodot + FromGodot;
+
+    /// Return a failure
+    fn failure(e: &Self::E) -> GResult {
+        GResult {
+            result: Result::Err(e.to_variant()),
+        }
+    }
+
+    /// Get the `Result` inside. This is safe.
+    fn unwrap(r: GResult) -> Result<Variant, Self::E> {
+        match r.result {
+            Ok(v) => Result::Ok(v),
+            Err(e) => Result::Err(Self::E::from_variant(&e)),
+        }
+    }
+}
+
+pub fn success<V: ToGodot>(v: V) -> GResult {
+    GResult {
+        result: Result::Ok(v.to_variant()),
+    }
+}

--- a/libcsl_godot/src/ledger/mod.rs
+++ b/libcsl_godot/src/ledger/mod.rs
@@ -1,0 +1,1 @@
+pub mod transaction;

--- a/libcsl_godot/src/ledger/transaction.rs
+++ b/libcsl_godot/src/ledger/transaction.rs
@@ -1,0 +1,77 @@
+use crate::bigint::BigInt;
+use cardano_serialization_lib as CSL;
+use godot::prelude::*;
+use CSL::crypto::{Vkeywitness, Vkeywitnesses};
+
+#[derive(GodotClass)]
+#[class(init, base=RefCounted, rename=Signature)]
+pub struct Signature {
+    pub signature: Option<Vkeywitness>,
+}
+
+#[derive(GodotClass, Debug)]
+#[class(init, base=RefCounted)]
+pub struct Utxo {
+    #[var(get)]
+    pub tx_hash: GString,
+    #[var(get)]
+    pub output_index: u32,
+    #[var(get)]
+    pub address: GString,
+    #[var(get)]
+    pub coin: Gd<BigInt>,
+    #[var(get)]
+    pub assets: Dictionary,
+}
+
+#[godot_api]
+impl Utxo {
+    #[func]
+    fn create(
+        tx_hash: GString,
+        output_index: u32,
+        address: GString,
+        coin: Gd<BigInt>,
+        assets: Dictionary,
+    ) -> Gd<Utxo> {
+        return Gd::from_object(Self {
+            tx_hash,
+            output_index,
+            address,
+            coin,
+            assets,
+        });
+    }
+}
+
+#[derive(GodotClass)]
+#[class(init, base=RefCounted, rename=Transaction)]
+pub struct Transaction {
+    pub transaction: Option<CSL::Transaction>,
+}
+
+#[godot_api]
+impl Transaction {
+    #[func]
+    fn bytes(&self) -> PackedByteArray {
+        let bytes_vec = self.transaction.clone().unwrap().to_bytes();
+        let bytes: &[u8] = bytes_vec.as_slice().into();
+        return PackedByteArray::from(bytes);
+    }
+
+    #[func]
+    fn add_signature(&mut self, signature: Gd<Signature>) {
+        // NOTE: destroys? transaction and replaces with a new one. might be better to add
+        // signatures to the witness set before the transaction is actually built
+        let transaction = self.transaction.as_ref().unwrap();
+        let mut witness_set = transaction.witness_set();
+        let mut vkey_witnesses = witness_set.vkeys().unwrap_or(Vkeywitnesses::new());
+        vkey_witnesses.add(signature.bind().signature.as_ref().unwrap());
+        witness_set.set_vkeys(&vkey_witnesses);
+        self.transaction = Some(CSL::Transaction::new(
+            &transaction.body(),
+            &witness_set,
+            transaction.auxiliary_data(),
+        ))
+    }
+}

--- a/libcsl_godot/src/lib.rs
+++ b/libcsl_godot/src/lib.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use cardano_serialization_lib::address::{Address, BaseAddress, NetworkInfo, StakeCredential};
 use cardano_serialization_lib::crypto::{
     Bip32PrivateKey, ScriptHash, TransactionHash, Vkeywitness, Vkeywitnesses,
@@ -7,7 +5,6 @@ use cardano_serialization_lib::crypto::{
 use cardano_serialization_lib::fees::LinearFee;
 use cardano_serialization_lib::output_builder::*;
 use cardano_serialization_lib::tx_builder::*;
-use cardano_serialization_lib::utils as CSL;
 use cardano_serialization_lib::utils::*;
 use cardano_serialization_lib::{
     AssetName, MultiAsset, Transaction, TransactionInput, TransactionOutput, TransactionWitnessSet,
@@ -17,80 +14,12 @@ use bip32::{Language, Mnemonic};
 
 use godot::prelude::*;
 
+pub mod bigint;
 pub mod gresult;
-use gresult::{success, FailsWith, GResult};
+
+use bigint::BigInt;
 
 struct MyExtension;
-
-#[derive(GodotClass, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[class(init, base=RefCounted)]
-struct BigInt {
-    #[init(default = CSL::BigInt::from_str("0").unwrap())]
-    #[doc(hidden)]
-    b: CSL::BigInt,
-}
-
-#[godot_api]
-impl BigInt {
-    #[func]
-    fn from_str(text: String) -> Gd<BigInt> {
-        let b = CSL::BigInt::from_str(&text).expect("Could not parse BigInt");
-        return Gd::from_object(Self { b });
-    }
-
-    #[func]
-    fn to_str(&self) -> String {
-        return self.b.to_str();
-    }
-
-    #[func]
-    fn to_string(&self) -> String {
-        return self.to_str();
-    }
-
-    #[func]
-    fn from_int(n: i64) -> Gd<BigInt> {
-        let b = CSL::BigInt::from_str(&n.to_string()).unwrap();
-        return Gd::from_object(Self { b });
-    }
-
-    #[func]
-    fn add(&self, other: Gd<BigInt>) -> Gd<BigInt> {
-        let b = self.b.add(&other.bind().deref().b);
-        return Gd::from_object(Self { b });
-    }
-
-    #[func]
-    fn mul(&self, other: Gd<BigInt>) -> Gd<BigInt> {
-        let b = self.b.mul(&other.bind().deref().b);
-        return Gd::from_object(Self { b });
-    }
-
-    #[func]
-    fn zero() -> Gd<BigInt> {
-        return Self::from_str("0".to_string());
-    }
-
-    #[func]
-    fn one() -> Gd<BigInt> {
-        return Self::from_str("1".to_string());
-    }
-
-    #[func]
-    fn eq(&self, other: Gd<BigInt>) -> bool {
-        return self.b == other.bind().b;
-    }
-
-    #[func]
-    fn gt(&self, other: Gd<BigInt>) -> bool {
-        return self > &other.bind();
-    }
-
-    #[func]
-    fn lt(&self, other: Gd<BigInt>) -> bool {
-        return self < &other.bind();
-    }
-}
 
 #[derive(GodotClass, Debug)]
 #[class(init, base=RefCounted)]

--- a/libcsl_godot/src/lib.rs
+++ b/libcsl_godot/src/lib.rs
@@ -1,35 +1,24 @@
 use std::ops::Deref;
 
-use cardano_serialization_lib::address::{
-    Address,
-    BaseAddress,
-    NetworkInfo,
-    StakeCredential
-};
+use cardano_serialization_lib::address::{Address, BaseAddress, NetworkInfo, StakeCredential};
 use cardano_serialization_lib::crypto::{
-    Bip32PrivateKey,
-    ScriptHash,
-    TransactionHash,
-    Vkeywitness,
-    Vkeywitnesses
+    Bip32PrivateKey, ScriptHash, TransactionHash, Vkeywitness, Vkeywitnesses,
 };
-use cardano_serialization_lib::utils::*;
+use cardano_serialization_lib::fees::LinearFee;
 use cardano_serialization_lib::output_builder::*;
 use cardano_serialization_lib::tx_builder::*;
-use cardano_serialization_lib::fees::LinearFee;
-use cardano_serialization_lib::{
-    AssetName,
-    MultiAsset,
-    Transaction,
-    TransactionInput,
-    TransactionOutput,
-    TransactionWitnessSet,
-};
 use cardano_serialization_lib::utils as CSL;
+use cardano_serialization_lib::utils::*;
+use cardano_serialization_lib::{
+    AssetName, MultiAsset, Transaction, TransactionInput, TransactionOutput, TransactionWitnessSet,
+};
 
-use bip32::{Mnemonic, Language};
+use bip32::{Language, Mnemonic};
 
 use godot::prelude::*;
+
+pub mod gresult;
+use gresult::{success, FailsWith, GResult};
 
 struct MyExtension;
 
@@ -38,10 +27,10 @@ struct MyExtension;
 struct BigInt {
     #[init(default = CSL::BigInt::from_str("0").unwrap())]
     #[doc(hidden)]
-    b: CSL::BigInt
+    b: CSL::BigInt,
 }
 
-#[godot_api] 
+#[godot_api]
 impl BigInt {
     #[func]
     fn from_str(text: String) -> Gd<BigInt> {
@@ -106,11 +95,16 @@ impl BigInt {
 #[derive(GodotClass, Debug)]
 #[class(init, base=RefCounted)]
 struct Utxo {
-    #[var(get)] tx_hash: GString,
-    #[var(get)] output_index: u32,
-    #[var(get)] address: GString,
-    #[var(get)] coin: Gd<BigInt>,
-    #[var(get)] assets: Dictionary
+    #[var(get)]
+    tx_hash: GString,
+    #[var(get)]
+    output_index: u32,
+    #[var(get)]
+    address: GString,
+    #[var(get)]
+    coin: Gd<BigInt>,
+    #[var(get)]
+    assets: Dictionary,
 }
 
 #[godot_api]
@@ -121,17 +115,15 @@ impl Utxo {
         output_index: u32,
         address: GString,
         coin: Gd<BigInt>,
-        assets: Dictionary
+        assets: Dictionary,
     ) -> Gd<Utxo> {
-        return Gd::from_object(
-            Self {
-                tx_hash,
-                output_index,
-                address,
-                coin,
-                assets
-            }
-        );
+        return Gd::from_object(Self {
+            tx_hash,
+            output_index,
+            address,
+            coin,
+            assets,
+        });
     }
 }
 
@@ -159,17 +151,15 @@ impl ProtocolParameters {
         linear_fee_constant: u64,
         linear_fee_coefficient: u64,
     ) -> Gd<ProtocolParameters> {
-        return Gd::from_object(
-            Self {
-                coins_per_utxo_byte,
-                pool_deposit,
-                key_deposit,
-                max_value_size,
-                max_tx_size,
-                linear_fee_constant,
-                linear_fee_coefficient,
-            }
-        );
+        return Gd::from_object(Self {
+            coins_per_utxo_byte,
+            pool_deposit,
+            key_deposit,
+            max_value_size,
+            max_tx_size,
+            linear_fee_constant,
+            linear_fee_coefficient,
+        });
     }
 }
 
@@ -180,7 +170,8 @@ fn harden(index: u32) -> u32 {
 #[derive(GodotClass)]
 #[class(init, base=RefCounted)]
 struct PrivateKeyAccount {
-    #[var] account_index: u32,
+    #[var]
+    account_index: u32,
 
     master_private_key: Option<Bip32PrivateKey>,
 }
@@ -195,27 +186,31 @@ impl PrivateKeyAccount {
                 .split_whitespace()
                 .collect::<Vec<_>>()
                 .join(" "),
-            Language::English
+            Language::English,
         );
         match result {
             Err(msg) => {
                 godot_print!("{}", msg);
-                return None
+                return None;
             }
             Ok(mnemonic) => {
                 // TODO: find out if the wrapped key will be freed by Gd
-                return Some(Gd::from_object(
-                    Self {
-                        master_private_key: Some(Bip32PrivateKey::from_bip39_entropy(mnemonic.entropy(), &[])),
-                        account_index: 0
-                    }
-                ))
+                return Some(Gd::from_object(Self {
+                    master_private_key: Some(Bip32PrivateKey::from_bip39_entropy(
+                        mnemonic.entropy(),
+                        &[],
+                    )),
+                    account_index: 0,
+                }));
             }
         }
     }
 
     fn get_account_root(&self) -> Bip32PrivateKey {
-        let priv_key = self.master_private_key.as_ref().expect("Private key not set");
+        let priv_key = self
+            .master_private_key
+            .as_ref()
+            .expect("Private key not set");
         return priv_key
             .derive(harden(1852))
             .derive(harden(1815))
@@ -228,12 +223,12 @@ impl PrivateKeyAccount {
         let stake = account_root.derive(2).derive(0).to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
-        let address =
-            BaseAddress::new(
-                NetworkInfo::testnet_preview().network_id(),
-                &spend_cred,
-                &stake_cred
-            ).to_address();
+        let address = BaseAddress::new(
+            NetworkInfo::testnet_preview().network_id(),
+            &spend_cred,
+            &stake_cred,
+        )
+        .to_address();
         return address;
     }
 
@@ -248,11 +243,9 @@ impl PrivateKeyAccount {
         let spend_key = account_root.derive(0).derive(0).to_raw_key();
         let tx_hash = hash_transaction(&tx.bind().transaction.as_ref().unwrap().body());
 
-        return Gd::from_object(
-            GSignature {
-                signature: Some(make_vkey_witness(&tx_hash, &spend_key))
-            }
-        )
+        return Gd::from_object(GSignature {
+            signature: Some(make_vkey_witness(&tx_hash, &spend_key)),
+        });
     }
 }
 
@@ -260,13 +253,13 @@ impl PrivateKeyAccount {
 #[derive(GodotClass)]
 #[class(init, base=RefCounted, rename=Signature)]
 struct GSignature {
-    signature: Option<Vkeywitness>
+    signature: Option<Vkeywitness>,
 }
 
 #[derive(GodotClass)]
 #[class(init, base=RefCounted, rename=Transaction)]
 struct GTransaction {
-    transaction: Option<Transaction>
+    transaction: Option<Transaction>,
 }
 
 #[godot_api]
@@ -287,13 +280,11 @@ impl GTransaction {
         let mut vkey_witnesses = witness_set.vkeys().unwrap_or(Vkeywitnesses::new());
         vkey_witnesses.add(signature.bind().signature.as_ref().unwrap());
         witness_set.set_vkeys(&vkey_witnesses);
-        self.transaction = Some(
-            Transaction::new(
-                &transaction.body(),
-                &witness_set,
-                transaction.auxiliary_data()
-            )
-        )
+        self.transaction = Some(Transaction::new(
+            &transaction.body(),
+            &witness_set,
+            transaction.auxiliary_data(),
+        ))
     }
 }
 
@@ -309,22 +300,20 @@ impl Cardano {
     fn set_protocol_parameters(&mut self, parameters: Gd<ProtocolParameters>) {
         let params = parameters.bind();
         godot_print!("Setting parameters");
-        self.tx_builder_config =
-            Some(
-                TransactionBuilderConfigBuilder::new()
-                    .coins_per_utxo_byte(&to_bignum(params.coins_per_utxo_byte))
-                    .pool_deposit(&to_bignum(params.pool_deposit))
-                    .key_deposit(&to_bignum(params.key_deposit))
-                    .max_value_size(params.max_value_size)
-                    .max_tx_size(params.max_tx_size)
-                    .fee_algo(
-                        &LinearFee::new(
-                            &to_bignum(params.linear_fee_coefficient),
-                            &to_bignum(params.linear_fee_constant)
-                        )
-                    )
-                    .build().expect("Failed to build transaction builder config")
-            );
+        self.tx_builder_config = Some(
+            TransactionBuilderConfigBuilder::new()
+                .coins_per_utxo_byte(&to_bignum(params.coins_per_utxo_byte))
+                .pool_deposit(&to_bignum(params.pool_deposit))
+                .key_deposit(&to_bignum(params.key_deposit))
+                .max_value_size(params.max_value_size)
+                .max_tx_size(params.max_tx_size)
+                .fee_algo(&LinearFee::new(
+                    &to_bignum(params.linear_fee_coefficient),
+                    &to_bignum(params.linear_fee_constant),
+                ))
+                .build()
+                .expect("Failed to build transaction builder config"),
+        );
     }
 
     #[func]
@@ -333,57 +322,100 @@ impl Cardano {
         recipient_bech32: String,
         change_address_bech32: String,
         amount: Gd<BigInt>,
-        gutxos: Array<Gd<Utxo>>
+        gutxos: Array<Gd<Utxo>>,
     ) -> Gd<GTransaction> {
         let tx_builder_config = self.tx_builder_config.as_ref().unwrap();
 
-        let recipient = Address::from_bech32(&recipient_bech32).expect("Could not decode address bech32");
-        let change_address = Address::from_bech32(&change_address_bech32).expect("Could not decode address bech32");
+        let recipient =
+            Address::from_bech32(&recipient_bech32).expect("Could not decode address bech32");
+        let change_address =
+            Address::from_bech32(&change_address_bech32).expect("Could not decode address bech32");
         let mut utxos: TransactionUnspentOutputs = TransactionUnspentOutputs::new();
         gutxos.iter_shared().for_each(|gutxo| {
             let utxo = gutxo.bind();
             let mut assets: MultiAsset = MultiAsset::new();
-            utxo.assets.iter_shared().typed().for_each(|(unit, amount): (GString, Gd<BigInt>)| {
-                assets.set_asset(
-                    &ScriptHash::from_hex(&unit.to_string().get(0..56).expect("Could not extract policy ID")).expect("Could not decode policy ID"),
-                    &AssetName::new(hex::decode(unit.to_string().get(56..).expect("Could not extract asset name")).unwrap().into()).expect("Could not decode asset name"),
-                    BigNum::from_str(&amount.bind().to_str()).unwrap()
-                );
-            });
-            utxos.add(
-                &TransactionUnspentOutput::new(
-                    &TransactionInput::new(
-                        &TransactionHash::from_hex(&utxo.tx_hash.to_string()).expect("Could not decode transaction hash"),
-                        utxo.output_index
-                    ),
-                    &TransactionOutput::new(
-                        &Address::from_bech32(&utxo.address.to_string()).expect("Could not decode address bech32"), 
-                        &Value::new_with_assets(
-                            &to_bignum(utxo.coin.bind().b.as_u64().expect("UTxO Lovelace exceeds maximum").into()),
-                            &assets
+            utxo.assets
+                .iter_shared()
+                .typed()
+                .for_each(|(unit, amount): (GString, Gd<BigInt>)| {
+                    assets.set_asset(
+                        &ScriptHash::from_hex(
+                            &unit
+                                .to_string()
+                                .get(0..56)
+                                .expect("Could not extract policy ID"),
                         )
-                    )
-                )
-            );
+                        .expect("Could not decode policy ID"),
+                        &AssetName::new(
+                            hex::decode(
+                                unit.to_string()
+                                    .get(56..)
+                                    .expect("Could not extract asset name"),
+                            )
+                            .unwrap()
+                            .into(),
+                        )
+                        .expect("Could not decode asset name"),
+                        BigNum::from_str(&amount.bind().to_str()).unwrap(),
+                    );
+                });
+            utxos.add(&TransactionUnspentOutput::new(
+                &TransactionInput::new(
+                    &TransactionHash::from_hex(&utxo.tx_hash.to_string())
+                        .expect("Could not decode transaction hash"),
+                    utxo.output_index,
+                ),
+                &TransactionOutput::new(
+                    &Address::from_bech32(&utxo.address.to_string())
+                        .expect("Could not decode address bech32"),
+                    &Value::new_with_assets(
+                        &to_bignum(
+                            utxo.coin
+                                .bind()
+                                .b
+                                .as_u64()
+                                .expect("UTxO Lovelace exceeds maximum")
+                                .into(),
+                        ),
+                        &assets,
+                    ),
+                ),
+            ));
         });
         let output_builder = TransactionOutputBuilder::new();
-        let amount_builder = output_builder.with_address(&recipient).next().expect("Failed to build transaction output");
-        let output = amount_builder.with_coin(&amount.bind().b.as_u64().expect("Output lovelace exceeds maximum")).build().expect("Failed to build amount output");
+        let amount_builder = output_builder
+            .with_address(&recipient)
+            .next()
+            .expect("Failed to build transaction output");
+        let output = amount_builder
+            .with_coin(
+                &amount
+                    .bind()
+                    .b
+                    .as_u64()
+                    .expect("Output lovelace exceeds maximum"),
+            )
+            .build()
+            .expect("Failed to build amount output");
         let mut tx_builder = TransactionBuilder::new(&tx_builder_config);
-        tx_builder.add_inputs_from(&utxos, CoinSelectionStrategyCIP2::LargestFirstMultiAsset).expect("Could not add inputs");
-        tx_builder.add_output(&output).expect("Could not add output");
-        tx_builder.add_change_if_needed(&change_address).expect("Could not set change address");
+        tx_builder
+            .add_inputs_from(&utxos, CoinSelectionStrategyCIP2::LargestFirstMultiAsset)
+            .expect("Could not add inputs");
+        tx_builder
+            .add_output(&output)
+            .expect("Could not add output");
+        tx_builder
+            .add_change_if_needed(&change_address)
+            .expect("Could not set change address");
         let tx_body = tx_builder.build().expect("Could not build transaction");
 
         let mut witnesses = TransactionWitnessSet::new();
         let vkey_witnesses = Vkeywitnesses::new();
         witnesses.set_vkeys(&vkey_witnesses);
 
-        return Gd::from_object(
-            GTransaction {
-                transaction: Some(Transaction::new(&tx_body, &witnesses, None))
-            }
-        )
+        return Gd::from_object(GTransaction {
+            transaction: Some(Transaction::new(&tx_body, &witnesses, None)),
+        });
     }
 }
 

--- a/libcsl_godot/src/lib.rs
+++ b/libcsl_godot/src/lib.rs
@@ -312,35 +312,35 @@ impl TxBuilder {
             Address::from_bech32(&recipient_bech32).expect("Could not decode address bech32");
         let change_address =
             Address::from_bech32(&change_address_bech32).expect("Could not decode address bech32");
+
         let mut utxos: TransactionUnspentOutputs = TransactionUnspentOutputs::new();
-        gutxos.iter_shared().for_each(|gutxo| {
+
+        for gutxo in gutxos.iter_shared() {
             let utxo = gutxo.bind();
             let mut assets: MultiAsset = MultiAsset::new();
-            utxo.assets
-                .iter_shared()
-                .typed()
-                .for_each(|(unit, amount): (GString, Gd<BigInt>)| {
-                    assets.set_asset(
-                        &ScriptHash::from_hex(
-                            &unit
-                                .to_string()
-                                .get(0..56)
-                                .expect("Could not extract policy ID"),
+            for (unit, amount) in utxo.assets.iter_shared().typed::<GString, Gd<BigInt>>() {
+                assets.set_asset(
+                    &ScriptHash::from_hex(
+                        &unit
+                            .to_string()
+                            .get(0..56)
+                            .expect("Could not extract policy ID"),
+                    )
+                    .expect("Could not decode policy ID"),
+                    &AssetName::new(
+                        hex::decode(
+                            unit.to_string()
+                                .get(56..)
+                                .expect("Could not extract asset name"),
                         )
-                        .expect("Could not decode policy ID"),
-                        &AssetName::new(
-                            hex::decode(
-                                unit.to_string()
-                                    .get(56..)
-                                    .expect("Could not extract asset name"),
-                            )
-                            .unwrap()
-                            .into(),
-                        )
-                        .expect("Could not decode asset name"),
-                        BigNum::from_str(&amount.bind().to_str()).unwrap(),
-                    );
-                });
+                        .unwrap()
+                        .into(),
+                    )
+                    .expect("Could not decode asset name"),
+                    BigNum::from_str(&amount.bind().to_str()).unwrap(),
+                );
+            }
+
             utxos.add(&TransactionUnspentOutput::new(
                 &TransactionInput::new(
                     &TransactionHash::from_hex(&utxo.tx_hash.to_string())
@@ -363,7 +363,7 @@ impl TxBuilder {
                     ),
                 ),
             ));
-        });
+        }
         let output_builder = TransactionOutputBuilder::new();
         let amount_builder = output_builder
             .with_address(&recipient)


### PR DESCRIPTION
Fix #15 #20 

* [x] Introduce `GResult` type and  `FailsWith` trait
* [x] Remove `Option` fields and `init` from some classes to disallow runtime errors due to bad initialization
    - GSignature
    - GTransaction
    - Cardano
    - PrivateKeyAccount
    - and possibly more
* [x]  Made `Cardano` a GDScript only class containing a `TxBuilder` inside / renamed the Cardano native class to `TxBuilder`. This lets us initialize `TxBuilder` independently of other things, like `Wallet` or `Provider`.
* [x] Remove `unwrap`s and `expect`s by modifying the function's signatures (return `Result`) and exposing GDScript-specific methods. Exception: the `send_lovelace` function: this requires implementing a few classes more, better suited for a separate PR. 
* [x] Refactor GDScript code to work with Rust changes. This meant wrapping most (if not all) native classes and adding `Status` enums and subclasses for return types.
* [x] Enable most warnings and modify the codebase to comply (I skipped INFERRED_DECLARATION, this one is annoying).

Although not necessary, I also made a few improvements to the demo:

* [x] `Wallet` and `Main`: switch from polling to awaiting a signal whenever possible
* [x] Show the timer for refreshing Utxos on screen