### PR TITLE
update gdext to fix exported projects

### DIFF
--- a/libcsl_godot/Cargo.lock
+++ b/libcsl_godot/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
@@ -327,7 +327,7 @@ checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "uuid",
 ]
 
@@ -353,7 +353,7 @@ checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
 [[package]]
 name = "godot"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "godot-bindings"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "godot4-prebuilt",
 ]
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "godot-codegen"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "godot-bindings",
  "godot-fmt",
@@ -384,7 +384,7 @@ dependencies = [
 [[package]]
 name = "godot-core"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "godot-ffi"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "gensym",
  "godot-bindings",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "godot-fmt"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "proc-macro2",
 ]
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "godot-macros"
 version = "0.1.0"
-source = "git+https://github.com/godot-rust/gdext?rev=7dee976484db8fc756a2442a9edebcaf48f2b677#7dee976484db8fc756a2442a9edebcaf48f2b677"
+source = "git+https://github.com/godot-rust/gdext?rev=4ce4714b8871bf75e95d03401e44e3f1ccbdd7df#4ce4714b8871bf75e95d03401e44e3f1ccbdd7df"
 dependencies = [
  "godot-bindings",
  "proc-macro2",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "linked-hash-map"
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "schemars"
@@ -810,7 +810,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -961,7 +961,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -983,7 +983,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/libcsl_godot/Cargo.toml
+++ b/libcsl_godot/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", rev = "7dee976484db8fc756a2442a9edebcaf48f2b677" }
+godot = { git = "https://github.com/godot-rust/gdext", rev = "4ce4714b8871bf75e95d03401e44e3f1ccbdd7df" }
 cardano-serialization-lib = "11.5.0"
 bip32 = "0.5.1"
 hex = "0.4.0"


### PR DESCRIPTION
exported application now runs correctly in debug mode (crashes in release mode)
this was the bug:
https://github.com/godotengine/godot/issues/86206
https://github.com/godot-rust/gdext/issues/489
