### PR TITLE
Add various debugging utility functions

### DIFF
--- a/addons/@mlabs-haskell/godot-cardano/src/plutus_data/plutus_data.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/plutus_data/plutus_data.gd
@@ -44,7 +44,10 @@ class_name PlutusData
 static func wrap(v: Variant) -> PlutusData:
 	match typeof(v):
 		TYPE_ARRAY:
-			return PlutusList.new(v.map(PlutusData.wrap))
+			var wrapped: Array[PlutusData] = []
+			for e in v:
+				wrapped.push_back(PlutusData.wrap(e))
+			return PlutusList.new(wrapped)
 		TYPE_DICTIONARY:
 			var wrapped: Dictionary = {}
 			for key: Variant in v:

--- a/addons/@mlabs-haskell/godot-cardano/src/plutus_data/plutus_list.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/plutus_data/plutus_list.gd
@@ -15,7 +15,7 @@ func _unwrap() -> Variant:
 	return unwrapped
 
 func _to_json() -> Dictionary:
-	return { "list": _data.map(to_json) }
+	return { "list": _data.map(func (v): return v.to_json()) }
 
 func get_data() -> Array[PlutusData]:
 	return _data

--- a/addons/@mlabs-haskell/godot-cardano/src/plutus_data/resource.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/plutus_data/resource.gd
@@ -57,12 +57,13 @@ var data_as_hex: String:
 	set(v):
 		if (v.length() % 2 == 0):
 			data_bytes = v.hex_decode()
-@export
-var data_as_utf8: String:
-	get:
-		return data_bytes.get_string_from_utf8()
-	set(v):
-		data_bytes = v.to_utf8_buffer()
+# FIXME: try to only decode if we can verify that these are valid UTF8 bytes
+#@export
+#var data_as_utf8: String:
+	#get:
+		#return data_bytes.get_string_from_utf8()
+	#set(v):
+		#data_bytes = v.to_utf8_buffer()
 
 var data_cbor: PackedByteArray:
 	get:

--- a/addons/@mlabs-haskell/godot-cardano/src/provider/provider_api.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/provider/provider_api.gd
@@ -254,7 +254,7 @@ func _get_tx_status(_tx_hash: TransactionHash) -> bool:
 ## inline datum set to it.[br]
 ## Otherwise, the result will contain the provided [param datum_hash]
 ## and, optionally, the [param datum_resolved_str] as the hashed data.
-func _build_datum_info(
+static func _build_datum_info(
 	datum_hash: String,
 	datum_inline_str: String,
 	datum_resolved_str: String,

--- a/addons/@mlabs-haskell/godot-cardano/src/transaction/transaction.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/transaction/transaction.gd
@@ -44,9 +44,8 @@ func add_signature(signature: Signature) -> void:
 ## Try to evaluate the transaction
 func evaluate(utxos: Array[Utxo]) -> EvaluationResult:
 	var _utxos: Array[_Utxo] = []
-	_utxos.assign(
-		utxos.map(func (utxo: Utxo) -> _Utxo: return utxo._utxo)
-	)
+	for utxo: Utxo in utxos:
+		_utxos.push_back(utxo._utxo)
 	return EvaluationResult.new(_tx._evaluate(_utxos))
 
 ## Get the unique hash of the transaction

--- a/addons/@mlabs-haskell/godot-cardano/src/transaction/tx_builder.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/transaction/tx_builder.gd
@@ -33,7 +33,11 @@ enum TxBuilderStatus {
 var _builder: _TxBuilder
 var _wallet: OnlineWallet
 var _provider: Provider
+
 var _results: Array[Result]
+
+var _scripts_added: bool = false
+var _script_substitutions: Dictionary = {}
 var _script_utxos: Array[Utxo]
 var _other_utxos: Array[Utxo]
 
@@ -112,6 +116,56 @@ class MintToken:
 	func _to_string() -> String:
 		return "%s" % { [_asset_name.to_hex()]: _quantity.to_str() }
 
+func _substitute_script_credential(cred: Credential) -> Credential:
+	if _script_substitutions.keys().is_empty() || cred == null:
+		return cred
+	
+	if cred.get_type() == Credential.CredentialType.KEY_HASH:
+		return cred
+	var sub = _script_substitutions.get(cred.to_script_hash().value.to_hex())
+	if sub != null:
+		return Credential.from_script_source(sub)
+	return cred
+
+func _substitute_address(address: Address) -> Address:
+	if _script_substitutions.keys().is_empty():
+		return address
+	
+	return _provider.make_address(
+		_substitute_script_credential(address.payment_credential()),
+		_substitute_script_credential(address.stake_credential()),
+	)
+
+func _substitute_assets(assets: MultiAsset) -> MultiAsset:
+	if _script_substitutions.keys().is_empty():
+		return assets
+		
+	var assets_dict := assets.to_dictionary()
+	for script_hash_hex: String in _script_substitutions:
+		var to_script_hash_hex: String = _script_substitutions[script_hash_hex].hash().to_hex()
+		var tokens := assets.get_tokens(PolicyId.from_hex(script_hash_hex).value)
+		for token: String in tokens:
+			if assets_dict.has(script_hash_hex + token):
+				assets_dict[to_script_hash_hex + token] = assets_dict.get(script_hash_hex + token)
+				assets_dict.erase(script_hash_hex + token)
+	return MultiAsset.from_dictionary(assets_dict).value
+
+func _substitute_utxo(utxo: Utxo) -> Utxo:
+	if _script_substitutions.keys().is_empty():
+		return utxo
+		
+	return Utxo.new(
+		_Utxo.create(
+			utxo._utxo.tx_hash,
+			utxo._utxo.output_index,
+			_substitute_address(utxo.address())._address,
+			utxo._utxo.coin,
+			_substitute_assets(utxo.assets())._multi_asset,
+			utxo._utxo.datum_info,
+			utxo._utxo.script_ref
+		)
+	)
+
 ## TODO: This probably shouldn't be exposed.
 ## Create a TxBuilder object from a Provider. You should use [method Provider.new_tx]
 ## instead of this method, since that one will make sure to initialize other
@@ -167,9 +221,9 @@ func pay_to_address(
 			datum_serialized = Datum.inline(serialize_result.value)
 	
 	_builder._pay_to_address(
-		address._address,
+		_substitute_address(address)._address,
 		coin._b,
-		assets._multi_asset,
+		_substitute_assets(assets)._multi_asset,
 		datum_serialized,
 		script_ref
 	)
@@ -200,7 +254,12 @@ func mint_assets(
 	_results.push_back(serialize_result)
 	if serialize_result.is_err():
 		return self
-		
+
+	minting_policy_source = _script_substitutions.get(
+		minting_policy_source.hash().to_hex(),
+		minting_policy_source
+	)
+
 	var tokens_dict: Dictionary = {}
 	tokens.map(
 		func (token: MintToken) -> void:
@@ -221,6 +280,8 @@ func mint_assets(
 	)
 
 	_results.push_back(result)
+	
+	_scripts_added = true
 	
 	return self
 
@@ -304,11 +365,9 @@ func pay_cip68_user_tokens_with_datum(
 ## Consume all the [param utxos] specified.
 func collect_from(utxos: Array[Utxo]) -> TxBuilder:
 	var _utxos: Array[_Utxo] = []
-	_utxos.assign(
-		utxos.map(
-			func (utxo: Utxo) -> _Utxo: return utxo._utxo
-		)
-	)
+	for utxo: Utxo in utxos:
+		_utxos.push_back(_substitute_utxo(utxo)._utxo)
+		
 	_builder._collect_from(_utxos)
 	_other_utxos.append_array(utxos)
 	return self
@@ -322,12 +381,14 @@ func collect_from_script(
 ) -> TxBuilder:
 	var serialize_result: Cbor.SerializeResult = redeemer.serialize()
 	
-	var _utxos: Array[_Utxo] = []
-	_utxos.assign(
-		utxos.map(
-			func (utxo: Utxo) -> _Utxo: return utxo._utxo
-		)
+	plutus_script_source = _script_substitutions.get(
+		plutus_script_source.hash().to_hex(),
+		plutus_script_source
 	)
+
+	var _utxos: Array[_Utxo] = []
+	for utxo: Utxo in utxos:
+		_utxos.push_back(_substitute_utxo(utxo)._utxo)
 	
 	_script_utxos.append_array(utxos)
 
@@ -339,6 +400,8 @@ func collect_from_script(
 		_utxos,
 		serialize_result.value
 	)
+	
+	_scripts_added = true
 	
 	return self
 
@@ -379,6 +442,18 @@ func add_reference_input(utxo: Utxo) -> TxBuilder:
 	_script_utxos.push_back(utxo)
 	return self
 
+## Substitutes any usage of [param from] in this transaction with [param to]. 
+## This is mainly useful for replacing scripts with alternative versions,
+## e.g. with extra traces enabled.
+func substitute_script(from: PlutusScriptSource, to: PlutusScriptSource) -> TxBuilder:
+	if _scripts_added:
+		push_error("`substitute_script` must be called before any scripts are added to the `TxBuilder`")
+		return self
+
+	_script_substitutions[from.hash().to_hex()] = to
+	
+	return self
+
 ## Only balance the transaction and return the result.[br]The resulting transaction
 ## will not have been evaluated and will have inaccurate script execution units,
 ## which may cause the transaction to fail at submission and potentially consume
@@ -392,9 +467,8 @@ func balance(utxos: Array[Utxo] = []) -> BalanceResult:
 		wallet_utxos = await _wallet._get_updated_utxos()
 		
 	var _wallet_utxos: Array[_Utxo] = []
-	_wallet_utxos.assign(
-		wallet_utxos.map(func (utxo: Utxo) -> _Utxo: return utxo._utxo)
-	)
+	for utxo: Utxo in wallet_utxos:
+		_wallet_utxos.push_back(_substitute_utxo(utxo)._utxo)
 	
 	var result: BalanceResult = null
 	if wallet_utxos.size() == 0:
@@ -431,9 +505,8 @@ func complete(utxos: Array[Utxo] = []) -> CompleteResult:
 		wallet_utxos = await _wallet._get_updated_utxos()
 
 	var _wallet_utxos: Array[_Utxo] = []
-	_wallet_utxos.assign(
-		wallet_utxos.map(func (utxo: Utxo) -> _Utxo: return utxo._utxo)
-	)
+	for utxo: Utxo in wallet_utxos:
+		_wallet_utxos.push_back(_substitute_utxo(utxo)._utxo)
 	
 	if wallet_utxos.size() == 0:
 		_results.push_back(
@@ -452,7 +525,10 @@ func complete(utxos: Array[Utxo] = []) -> CompleteResult:
 	_results.push_back(balance_result)
 	
 	if not error and balance_result.is_ok():
-		var eval_result := balance_result.value.evaluate(wallet_utxos + _script_utxos)
+		var sub_script_utxos: Array[Utxo] = []
+		for utxo: Utxo in _script_utxos:
+			sub_script_utxos.push_back(_substitute_utxo(utxo))
+		var eval_result := balance_result.value.evaluate(wallet_utxos + sub_script_utxos)
 		
 		_results.push_back(eval_result)
 		if eval_result.is_ok():

--- a/addons/@mlabs-haskell/godot-cardano/src/transaction/utxo.gd
+++ b/addons/@mlabs-haskell/godot-cardano/src/transaction/utxo.gd
@@ -121,3 +121,27 @@ func to_script_source() -> PlutusScriptSource:
 	if _utxo.script_ref == null:
 		return null
 	return PlutusScriptSource.from_ref(_utxo)
+
+## Creates a duplicate of this UTxO with [param new_datum] as the new datum value.
+## Mainly useful for script testing and debugging. Returns null if the datum
+## value cannot be serialized.
+func replace_datum(new_datum: PlutusData) -> Utxo:
+	var serialize_result := new_datum.serialize()
+	
+	if serialize_result.is_err():
+		push_error("Utxo.replace_datum: Failed to serialize datum")
+		return null
+
+	return Utxo.create(
+		tx_hash().to_hex(),
+		output_index(),
+		address().to_bech32(),
+		coin().to_str(),
+		assets().to_dictionary(),
+		ProviderApi._build_datum_info(
+			_Cbor.hash_plutus_data(serialize_result.value).hex_encode(),
+			serialize_result.value.hex_encode(),
+			""
+		),
+		null
+	).value

--- a/demo/city_token_00.tres
+++ b/demo/city_token_00.tres
@@ -11,7 +11,6 @@ data_type = 0
 data_int = 0
 data_bytes = PackedByteArray()
 data_as_hex = ""
-data_as_utf8 = ""
 data_cbor_hex = "00"
 data_json = "{
   \"int\": \"0\"

--- a/libcsl_godot/src/plutus.rs
+++ b/libcsl_godot/src/plutus.rs
@@ -309,6 +309,14 @@ impl Cbor {
     fn _from_variant(variant: Variant) -> Gd<GResult> {
         Self::to_gresult_class(Self::from_variant(variant))
     }
+
+    #[func]
+    fn hash_plutus_data(bytes: PackedByteArray) -> PackedByteArray {
+        PackedByteArray::from(
+            cardano_serialization_lib::chain_crypto::Blake2b256::new(bytes.to_vec().as_slice())
+                .as_hash_bytes(),
+        )
+    }
 }
 
 // FIXME: shouldn't fail if provided with `PlutusData` types from GDScript,


### PR DESCRIPTION
- Add `TxBuilder.substitute_script`
- Make `ProviderApi.build_datum_info` static
- Add `Utxo.replace_datum`
- Fix minor bugs in PlutusData workflows
- Add `Cbor.hash_plutus_data`

Note: it may be better to implement script substitution for the balanced transaction rather than in `TxBuilder` later